### PR TITLE
feat: add skill tags to projects

### DIFF
--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -7,7 +7,7 @@ const cardColors = [
   'from-sunset-orange to-sunset-brown',
 ];
 
-export function Card({ title, description, github, colorIdx }: { title: string; description: string; github: string; colorIdx: number }) {
+export function Card({ title, description, github, tags, colorIdx }: { title: string; description: string; github: string; tags: string[]; colorIdx: number }) {
   return (
     <div
       className={clsx(
@@ -25,6 +25,16 @@ export function Card({ title, description, github, colorIdx }: { title: string; 
         <p className="text-sunset-peach/90 mb-4 text-base">
           {description}
         </p>
+        <ul className="flex flex-wrap gap-2 mt-2">
+          {tags.map((tag) => (
+            <li
+              key={tag}
+              className="bg-sunset-brown/60 text-sunset-peach text-xs px-2 py-1 rounded"
+            >
+              {tag}
+            </li>
+          ))}
+        </ul>
       </div>
       <div className="flex items-center mt-auto">
         <Link href={github} target="_blank" rel="noopener noreferrer" className="inline-flex items-center text-sunset-peach/80 hover:text-sunset-peach transition-colors">

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -3,21 +3,25 @@ export const projects = [
     title: 'Demographic Challenge',
     description: 'Exploration of education, equality, and ownership in Switzerland.',
     github: 'https://github.com/mikeandrusyak/Demografie-Challenge',
+    tags: ['Python', 'Data Analysis', 'Jupyter Notebook'],
   },
   {
     title: 'Correlation Visualization',
     description: 'Comparing correlation plots using Plotly in R for datasets of different sizes.',
     github: 'https://github.com/mikeandrusyak/correlation_with_plotly',
+    tags: ['R', 'Plotly', 'Data Visualization'],
   },
   {
     title: 'Delivery Time Simulation',
     description: 'Simulation of package delivery delays using Python and Jupyter Notebook.',
     github: 'https://github.com/mikeandrusyak/simulation_of_the_delivery_time',
+    tags: ['Python', 'Simulation', 'Jupyter Notebook'],
   },
   {
     title: 'Robot Challenge',
     description: 'Training a robot car to follow a map and perform tasks. Includes Jupyter Notebook and video.',
     github: 'https://github.com/mikeandrusyak/robot_challenge',
+    tags: ['Python', 'Robotics', 'Jupyter Notebook'],
   },
 ];
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -118,6 +118,7 @@ export default function Home() {
                   title={project.title}
                   description={project.description}
                   github={project.github}
+                  tags={project.tags}
                   colorIdx={idx}
                 />
               </motion.div>


### PR DESCRIPTION
## Summary
- list key skills for each project via new tags
- render project tags in project cards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68988056ffe4832292b609abedea8cad